### PR TITLE
Issue with response from HA

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -70,6 +70,7 @@ function isHaRunning() {
   
   var headers = {
     'Authorization': "Bearer "+HA_TOKEN,
+    'Content-Type' : "application/json",
   };
     
   var options =


### PR DESCRIPTION
Without this header, an error 400 is gotten from HA in new versions. This fixes it.